### PR TITLE
Tweaking the php opening tag in default.config.php

### DIFF
--- a/default.config.php
+++ b/default.config.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * Do not modify the default.config.php file, instead, override the settings in the config.php file
  */


### PR DESCRIPTION
Mentioned in the issue, that this short opening PHP tag will cause difficult to find the issue if short PHP tags are disabled in PHP configuration. The index.php just sends the content of config in the response, exposing potentially sensitive data